### PR TITLE
Fix completions and evaluate command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ test = [
 ]
 
 [project.scripts]
-issue-tools = "issue_tools.cli:app"
+issue-tools = "issue_tools.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/issue_tools/commands.py
+++ b/src/issue_tools/commands.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Iterable, List, Optional, Literal
 
 from .clustering import Cluster as RawCluster, kmeans, cluster_documents, gather_documents_for_clustering
@@ -142,7 +142,7 @@ class StreamItemSummary:
     updated_at: str
     created_at: str
     author: Optional[str]
-    labels: List[str]
+    labels: List[str] = field(default_factory=list)
 
 
 @dataclass(slots=True)

--- a/src/issue_tools/search.py
+++ b/src/issue_tools/search.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Optional
 
 from .embeddings import EmbeddingsClient
@@ -21,10 +21,10 @@ class SearchMatch:
     state: str
     doc_type: str
     labels: List[str]
-    label_details: List[LabelDetail]
     updated_at: str
     created_at: str
     author: Optional[str]
+    label_details: List[LabelDetail] = field(default_factory=list)
 
 
 class SearchService:


### PR DESCRIPTION
## Summary
- wrap the CLI with a custom `main` entry point that patches the generated completion scripts so they work with the repository wrapper
- allow using the deterministic fake embedding client when the config requests it so evaluate can run without a Gemini key
- provide defaults for command result dataclasses that appear in the API surface

## Testing
- `./.venv/bin/pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cdef78d3f4832bbe947f0ad6b0deae